### PR TITLE
Support immutable struct

### DIFF
--- a/lib/type_struct.rb
+++ b/lib/type_struct.rb
@@ -27,6 +27,7 @@ class TypeStruct
         end
       end
       instance_variable_set("@#{k}", sym_h[k])
+      sym_h[k].freeze if self.class.frozen?
     end
     raise MultiTypeError, errors unless errors.empty?
   end
@@ -90,6 +91,15 @@ class TypeStruct
 
     def valid?(k, v)
       definition[k] === v
+    end
+
+    def freeze
+      definition.each do |k, _|
+        define_method("#{k}=") do |*|
+          raise RuntimeError, "can't modify frozen #{self}##{k}"
+        end
+      end
+      super
     end
   end
 

--- a/test/type_struct_test.rb
+++ b/test/type_struct_test.rb
@@ -662,6 +662,27 @@ module TypeStructTest
     end
   end
 
+  def test_s_freeze(t)
+    t_class = TypeStruct.new(foo: String)
+    t_class.freeze
+    unless t_class.frozen?
+      t.error("should be frozen")
+    end
+    t_instance = t_class.new(foo: "bar")
+
+    [
+      [->{ t_instance.foo << "baz" }, RuntimeError],
+      [->{ t_instance.foo = "baz" }, RuntimeError]
+    ].each do |proc, err|
+      begin
+        proc.call
+      rescue err
+      else
+        t.error("expect raise #{err}")
+      end
+    end
+  end
+
   class Sample < TypeStruct.new(
     str: String,
     reg: /exp/,


### PR DESCRIPTION
This PR is an experimental function for immutable struct.

Just call `freeze` method if you want to make immutable struct.

```rb
Foo = TypeStruct.new(
  bar: String
).freeze
foo = Foo.new(bar: "bar")

# remove `bar=` method
foo.bar = "baz" #=> RuntimeError: can't modify frozen #<Foo bar="bar">#bar

# freeze value object
foo.bar << "baz" #=> RuntimeError: can't modify frozen String
```