### PR TITLE
Fix nested type_struct with to_h

### DIFF
--- a/lib/type_struct.rb
+++ b/lib/type_struct.rb
@@ -56,7 +56,7 @@ class TypeStruct
   def to_h
     m = {}
     self.class.members.each do |k|
-      m[k] = self[k]
+      m[k] = self[k].is_a?(TypeStruct) ? self[k].to_h : self[k]
     end
     m
   end

--- a/test/type_struct_test.rb
+++ b/test/type_struct_test.rb
@@ -31,6 +31,13 @@ module TypeStructTest
     e: ArrayOf(B),
     f: HashOf(String, Integer),
   )
+  Child = TypeStruct.new(
+    str: String
+  )
+  Parent = TypeStruct.new(
+    str: String,
+    child: Child
+  )
 
   def test_s_from_hash_a(t)
     a = A.from_hash(
@@ -524,6 +531,17 @@ module TypeStructTest
     expects.each do |k, v|
       unless dummy[k] == v
         t.error("expect #{dummy[k]} got #{v}")
+      end
+    end
+  end
+
+  def test_to_h_nested_type_struct(t)
+    expects = { str: "aaa", child: { str: "bbb" } }
+
+    parent = Parent.new(str: "aaa", child: Child.new(str: "bbb")).to_h
+    expects.each do |k, v|
+      unless parent[k] == v
+        t.error("expect #{parent[k]} got #{v}")
       end
     end
   end


### PR DESCRIPTION
I want to convert TypeStruct instance to XML.

For example in rails

```ruby
Child = TypeStruct.new(
  name: String
)

Parent = TypeStruct.new(
  name: String,
  child: Child
)

Parent.new(
  name: "Anakin Skywalker", 
  child: Child.new(name: 'Luke Skywalker')
).to_h.to_xml
```

But to_h dosen't return my expectation.

```ruby
{:name=>"Anakin Skywalker", :child=>#<Child name="Luke Skywalker">}
```

I expect following result.

```ruby
{:name=>"Anakin Skywalker", :child=>{:name=>"Luke Skywalker"}}
```