### PR TITLE
Support all string value for key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: ruby
 rvm:
   - 2.1.8
   - 2.2.4
-  - 2.3.0
+  - 2.3.7
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 before_install: gem install bundler -v 1.10.6
 notifications:
   email: false

--- a/lib/type_struct.rb
+++ b/lib/type_struct.rb
@@ -26,10 +26,10 @@ class TypeStruct
           errors << e
         end
       end
-      instance_variable_set("@#{k}", sym_h[k])
       sym_h[k].freeze if self.class.frozen?
     end
     raise MultiTypeError, errors unless errors.empty?
+    @__store = sym_h
   end
 
   def ==(other)
@@ -180,14 +180,14 @@ class TypeStruct
 
         args.each_key do |k|
           define_method(k) do
-            instance_variable_get("@#{k}")
+            @__store[k]
           end
 
           define_method("#{k}=") do |v|
             unless self.class.valid?(k, v)
               raise TypeError, "#{self.class}##{k} expect #{self.class.type(k)} got #{v.inspect}"
             end
-            instance_variable_set("@#{k}", v)
+            @__store[k] = v
           end
         end
       end

--- a/test/type_struct_test.rb
+++ b/test/type_struct_test.rb
@@ -228,6 +228,28 @@ module TypeStructTest
     end
   end
 
+  def test_s_from_hash_with_non_alphabet(t)
+    issues_8 = TypeStruct.new(:'hoge-id' => String)
+    v = begin
+      issues_8.from_hash('hoge-id' => '123456')
+    rescue => e
+      t.error("regression! https://github.com/ksss/type_struct/issues/8")
+    end
+    unless v['hoge-id'] == '123456'
+      t.error("regression! https://github.com/ksss/type_struct/issues/8")
+    end
+
+    type = TypeStruct.new(:'\"\\\/\b\f\n\r\t\uffff' => Integer)
+    v = begin
+      type.from_hash('\"\\\/\b\f\n\r\t\uffff' => 123456)
+    rescue => e
+      t.error("regression! https://github.com/ksss/type_struct/issues/8")
+    end
+    unless v['\"\\\/\b\f\n\r\t\uffff'] == 123456
+      t.error("regression! https://github.com/ksss/type_struct/issues/8")
+    end
+  end
+
   def test_s_from_hash_with_other_object(t)
     a = TypeStruct.new(a: Integer)
     o = Object.new


### PR DESCRIPTION
Fixed #8

$ bundle exec rgot -v --bench . --cpu=1 --thread=1

before:
benchmark_new_instance	480000	2133 ns/op
benchmark_struct_new_instance	7200000	139 ns/op
benchmark_from_hash	86400	11735 ns/op
benchmark_new	86400	13214 ns/op
benchmark_struct_new	72000	15985 ns/op

after:
benchmark_new_instance	864000	1314 ns/op
benchmark_struct_new_instance	7200000	142 ns/op
benchmark_from_hash	103680	10546 ns/op
benchmark_new	86400	12940 ns/op
benchmark_struct_new	72000	15447 ns/op