### PR TITLE
Improve `TypeError` identification by defining a custom error class

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ p sample.str
 #=> "instance of String"
 
 sample.string #=> NoMethodError
-sample.str = 1 #=> TypeError
+sample.str = 1 #=> TypeStruct::TypeError
 ```
 
 ### Recursive Mapping
@@ -184,8 +184,8 @@ Baz = TypeStruct.new(
 )
 p Baz.new(qux: { "a" => [1, 2, 3] }) #=> #<Baz qux={"a"=>[1, 2, 3]}>
 p Baz.from_hash(qux: { "a" => [1, 2, 3] }) #<Baz qux={"a"=>[1, 2, 3]}>
-p Baz.new(qux: { :a  => [1, 2, 3] }) #=> TypeError
-p Baz.new(qux: { "a" => [1, 2, nil] }) #=> TypeError
+p Baz.new(qux: { :a  => [1, 2, 3] }) #=> TypeStruct::TypeError
+p Baz.new(qux: { "a" => [1, 2, nil] }) #=> TypeStruct::TypeError
 ```
 
 ### Interface
@@ -200,7 +200,7 @@ Foo = TypeStruct.new(
   # or Interface.new(:read, :write) on required 'type_struct/ext'
 )
 Foo.new(bar: $stdin)
-Foo.new(bar: 1) #=> TypeError
+Foo.new(bar: 1) #=> TypeStruct::TypeError
 ```
 
 ### Mix
@@ -214,7 +214,7 @@ Baz = TypeStruct.new(
 p Baz.new(qux: [1]) #=> #<AAA::Baz qux=[1]>
 p Baz.new(qux: [true, false]) #=> #<AAA::Baz qux=[true, false]>
 p Baz.new(qux: nil) #=> #<AAA::Baz qux=nil>
-p Baz.new(qux: 1) #=> TypeError
+p Baz.new(qux: 1) #=> TypeStruct::TypeError
 p Baz.from_hash(qux: [1, 2, false, true]) #=> #<A::Baz qux=[1, 2, false, true]>
 ```
 

--- a/lib/type_struct/exceptions.rb
+++ b/lib/type_struct/exceptions.rb
@@ -1,5 +1,6 @@
 class TypeStruct
   UnionNotFoundError = Class.new(StandardError)
+  TypeError = Class.new(::TypeError)
 
   class MultiTypeError < StandardError
     THIS_LIB_REGEXP = %r{lib/type_struct[./]}

--- a/lib/type_struct_test.rb
+++ b/lib/type_struct_test.rb
@@ -277,8 +277,8 @@ module TypeStructTest
       a.from_hash(a: 1, b: 'a')
     rescue TypeStruct::MultiTypeError => e
       [
-        %r{lib/type_struct_test.rb:#{line}:in TypeError.*?#a expect ArrayOf\(Integer\) got 1}o,
-        %r{lib/type_struct_test.rb:#{line}:in TypeError.*?#b expect Integer got "a"}o,
+        %r{lib/type_struct_test.rb:#{line}:in TypeStruct::TypeError.*?#a expect ArrayOf\(Integer\) got 1}o,
+        %r{lib/type_struct_test.rb:#{line}:in TypeStruct::TypeError.*?#b expect Integer got "a"}o,
       ].each do |expect|
         unless expect =~ e.message
           t.error("message was changed: #{e.message}")
@@ -503,9 +503,12 @@ module TypeStructTest
     o = Object.new
     begin
       t.new(o)
-    rescue TypeError
+    rescue TypeStruct::TypeError => e
+      unless e.is_a?(::TypeError)
+        t.error("expect TypeStruct::TypeError is inherit of TypeError")
+      end
     else
-      t.error("expect TypeError")
+      t.error("expect TypeStruct::TypeError")
     end
     def o.to_hash
       {foo: "a"}


### PR DESCRIPTION
## I have suggestions

The current behavior of the `type_struct gem` returns a standard Ruby `TypeError` class. However, when catching `TypeError` in frameworks like Ruby on Rails, it can be challenging to determine whether it originated from the `type_struct gem`.

- resolves #14

## How

This pull request proposes the following changes:

Define a new custom error class, `TypeStruct::TypeError`, inherited from `TypeError`.

### Benefits

Improved error identification: Users can easily distinguish between standard Ruby `TypeError` and `TypeStruct::TypeError`, facilitating more targeted debugging.
Seamless integration: The introduction of the custom error class doesn't disrupt the existing usage of standard Ruby `TypeError`.


### Examples

```rb
# app/controllers/application_controller.rb

class ApplicationController < ActionController::Base
  # ...

  # Example of using rescue_from with TypeStruct::TypeError
  rescue_from TypeStruct::TypeError do |e|
    # Customize the error response as needed
    render status: :unprocessable_entity,
           json: { error: 'TypeStruct error', message: e.message }
  end

  # ...
end
```

These changes enhance error handling in a Ruby on Rails context by allowing for more precise identification of errors originating from the `type_struct gem`.
