### PR TITLE
Change error class from `TypeError` to `TypeStruct::MultiTypeError` on `from_hash` with other object than Hash

### DIFF
--- a/lib/type_struct.rb
+++ b/lib/type_struct.rb
@@ -64,7 +64,11 @@ class TypeStruct
   module ClassMethods
     def from_hash(arg)
       unless h = Hash.try_convert(arg)
-        raise TypeError, "no implicit conversion from #{arg} to Hash"
+        begin
+          raise TypeError, "no implicit conversion from #{arg} to Hash"
+        rescue => e
+          raise TypeStruct::MultiTypeError, [e]
+        end
       end
       args = {}
       errors = []

--- a/lib/type_struct_test.rb
+++ b/lib/type_struct_test.rb
@@ -255,11 +255,11 @@ module TypeStructTest
     o = Object.new
     begin
       a.from_hash(o)
-    rescue TypeError => e
+    rescue TypeStruct::MultiTypeError => e
     rescue => e
       t.error("Unexpected error #{e.class}")
     else
-      t.error("should raise TypeError")
+      t.error("should raise MultiTypeError")
     end
 
     def o.to_hash


### PR DESCRIPTION
## I have suggestions

This PR proposes changing the exception raised in the `TypeStruct#from_hash` method from `TypeError` to `TypeStruct::MultiTypeError` when the input is not a `Hash` object.

- resolves #14

## Background

The `TypeStruct#from_hash` method is used to construct a `TypeStruct` from a `Hash` object. In scenarios such as with Ruby on Rails controllers handling invalid JSON requests, the current implementation raises a `TypeError` when a non-Hash object is passed. This `TypeError` is widely used across different contexts.

### Example

Current behavior in Ruby on Rails:

```rb
# app/controllers/application_controller.rb

class ApplicationController < ActionController::Base

  # Error handling TypeError <= This may receive errors due to other factors.
  rescue_from TypeError do |e|
    # Customize the error response as needed
    render status: :unprocessable_entity,
           json: { error: 'Invalid body error', message: e.message }
  end

  # ...

  def update
    TitleParser = TypeStruct.new(title: String)
    ContentParser = TypeStruct.new(content: TitleParser)

    request_hash = JSON.parse(request.body.read)
    # => {content: [{title: 'hoge'}]} # `content` is should be an object, but an array
    ContentParser.from_hash(request_hash) # => TypeError
    # ...
  end

  # ...
end
```

## Solution

By changing `TypeStruct::MultiTypeError`, we can provide more specific error messages that detail the nature of the type mismatch, improving error traceability and specificity. This enhancement aids developers in pinpointing the exact nature of the issue, making debugging more straightforward and enhancing overall code maintainability.

### Proposed changes in error handling:

```rb
# app/controllers/application_controller.rb

class ApplicationController < ActionController::Base

  # Example of using rescue_from with TypeStruct::MultiTypeError
  rescue_from TypeStruct::MultiTypeError do |e|
    # Customize the error response as needed
    render status: :unprocessable_entity,
           json: { error: 'Invalid body error', message: e.message }
  end

  # ...
end
```

## Note

I believe this improvement will significantly benefit our project by making error handling more intuitive and debugging processes more efficient. If you agree with these changes, I kindly ask for your review and approval to merge this pull request.

Thank you for considering this enhancement.
